### PR TITLE
feat: 검색 조건 파싱 오류 처리용 BadRequestException 및 전역 예외 핸들러 추가

### DIFF
--- a/src/main/java/com/trevari/project/exception/BadRequestException.java
+++ b/src/main/java/com/trevari/project/exception/BadRequestException.java
@@ -1,0 +1,7 @@
+package com.trevari.project.exception;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/trevari/project/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/trevari/project/exception/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.trevari.project.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * 요청이 올바르지 않은 경우 400 BadRequest 응답 반환
+     */
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<Map<String, String>> handleBadRequestException(BadRequestException ex) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("status", "error");
+        errorResponse.put("message", ex.getMessage());
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+}


### PR DESCRIPTION
"키워드가 2개 이상인 경우, 파싱 과정에서 예외 발생" 처리를 위한 커밋

설명:
- 검색 조건 파싱 중 발생하는 입력 오류를 처리하기 위해 `BadRequestException` 예외 클래스 추가
- 이를 잡아 HTTP 400 응답을 반환하는 `GlobalExceptionHandler` 추가

변경 파일:
- `BadRequestException.java` — 요청 오류용 RuntimeException 추가
- `GlobalExceptionHandler.java` — `BadRequestException`을 잡아 400 응답 반환
