### PR TITLE
refactor(Book): 불필요한 인덱스 제거

### DIFF
--- a/src/main/java/com/trevari/project/domain/Book.java
+++ b/src/main/java/com/trevari/project/domain/Book.java
@@ -10,14 +10,7 @@ import java.time.LocalDate;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode(of = "isbn")
 @Entity
-@Table(
-        name = "books",
-        indexes = {
-                @Index(name = "idx_books_title", columnList = "title"),
-                @Index(name = "idx_books_author", columnList = "author"),
-                @Index(name = "idx_books_publisher", columnList = "publisher")
-        }
-)
+@Table(name = "books")
 public class Book {
 
     @Id


### PR DESCRIPTION
## 요약

**수정**: BOOKS 테이블에서 INDEX 제거
**근거**: 이번 과제에서는 LIKE('%kw%') 연산을 사용해야 하므로, INDEX 사용이 적절치 않음.
