### PR TITLE
dependency: H2 데이터베이스 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
     // JUnit Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // H2 DB for DataJpaTest
+    runtimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
#11 PR에서 빠뜨린 내용을 추가합니다.

슬라이스 테스트 코드 구동을 위해서는 H2 데이터베이스 의존성이 필요합니다.