### PR TITLE
feat(search): SIMPLE 기능 전용 파싱 메서드 추가

### DIFF
--- a/src/main/java/com/trevari/project/search/SearchQuery.java
+++ b/src/main/java/com/trevari/project/search/SearchQuery.java
@@ -1,16 +1,4 @@
 package com.trevari.project.search;
 
-import lombok.AllArgsConstructor;
-
-@AllArgsConstructor
-public class SearchQuery {
-    private final String query;
-    private final String left;
-    private final String right;
-    private final SearchStrategy strategy;
-
-    public String query() { return query; }
-    public String left() { return left; }
-    public String right() { return right; }
-    public SearchStrategy strategy() { return strategy; }
+public record SearchQuery(String query, String left, String right, SearchStrategy strategy) {
 }

--- a/src/main/java/com/trevari/project/search/SearchQueryParser.java
+++ b/src/main/java/com/trevari/project/search/SearchQueryParser.java
@@ -2,43 +2,78 @@ package com.trevari.project.search;
 
 import com.trevari.project.exception.BadRequestException;
 
-public class SearchQueryParser {
-    // supports: keyword, a|b, a-b (max 2 keywords)
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+public final class SearchQueryParser {
+
+    private SearchQueryParser() {}
+
+    // 공백-연산자-공백을 단일 기호로 정규화하기 위한 패턴 (재사용)
+    private static final Pattern WS_AROUND_PIPE  = Pattern.compile("\\s*\\|\\s*");
+    private static final Pattern WS_AROUND_MINUS = Pattern.compile("\\s*-\\s*");
+
+    /** 단순 검색: 리터럴 그대로 SIMPLE로 */
+    public static SearchQuery simple(String q) {
+        return parseInternal(q, false);
+    }
+
+    /** 연산자 허용: OR('|'), NOT('-'), 없으면 SIMPLE */
     public static SearchQuery parse(String q) {
-        if (q == null || q.trim().isEmpty()) {
-            throw new BadRequestException("search query must not be blank");
+        return parseInternal(q, true);
+    }
+
+    /** 내부 단일 진입점: 항상 정규화 선행 + 분기 */
+    private static SearchQuery parseInternal(String q, boolean allowOperators) {
+        String normalized = normalize(q);              // 1) trim + toLowerCase
+        if (!allowOperators) {
+            // 연산자 해석 없이 그대로 SIMPLE
+            return new SearchQuery(normalized, normalized, null, SearchStrategy.SIMPLE);
         }
-        String s = q.trim();
-        // 전체 문자열 정규화 (공백 제거 + 소문자 변환)
-        String normalized = norm(s);
-        // 연산자 좌우 공백 제거하는 작업: "a | b" 와 "a|b" 를 동일하게 처리
-        String normalizedOps = normalized.replaceAll("\\s*\\|\\s*", "|")
-                        .replaceAll("\\s*-\\s*", "-");
-        int pipe = normalizedOps.indexOf('|');
-        int minus = normalizedOps.indexOf('-');
+
+        // 2) 연산자 좌우 공백 정규화
+        String ops = normalizeOperators(normalized);
+
+        // 3) 연산자 판별 및 검증
+        int pipe  = ops.indexOf('|');
+        int minus = ops.indexOf('-');
+
         if (pipe >= 0 && minus >= 0) {
             throw new BadRequestException("Use only one operator: '|' or '-' with up to 2 keywords");
         }
+
         if (pipe >= 0) {
-            String[] parts = normalizedOps.split("\\|", -1);
+            String[] parts = ops.split("\\|", -1);
+            if (parts.length != 2) throw new BadRequestException("Invalid OR query, use 'a|b'");
             String left = parts[0].trim();
             String right = parts[1].trim();
-            if (parts.length != 2 || left.isBlank() || right.isBlank()) {
-                throw new BadRequestException("Invalid OR query, use 'a|b'");
-            }
-            return new SearchQuery(normalizedOps, left, right, SearchStrategy.OR_OPERATION);
+            if (left.isBlank() || right.isBlank()) throw new BadRequestException("Invalid OR query, use 'a|b'");
+            return new SearchQuery(ops, left, right, SearchStrategy.OR_OPERATION);
         }
+
         if (minus >= 0) {
-            String[] parts = normalizedOps.split("-", -1);
+            String[] parts = ops.split("-", -1);
+            if (parts.length != 2) throw new BadRequestException("Invalid NOT query, use 'a-b'");
             String left = parts[0].trim();
             String right = parts[1].trim();
-            if (parts.length != 2 || left.isBlank() || right.isBlank()) {
-                throw new BadRequestException("Invalid NOT query, use 'a-b'");
-            }
-            return new SearchQuery(normalizedOps, left, right, SearchStrategy.NOT_OPERATION);
+            if (left.isBlank() || right.isBlank()) throw new BadRequestException("Invalid NOT query, use 'a-b'");
+            return new SearchQuery(ops, left, right, SearchStrategy.NOT_OPERATION);
         }
-        return new SearchQuery(normalizedOps, normalizedOps.trim(), null, SearchStrategy.SIMPLE);
+
+        // 연산자 없음 → SIMPLE
+        return new SearchQuery(normalized, normalized, null, SearchStrategy.SIMPLE);
     }
 
-    private static String norm(String kw) { return kw.trim().toLowerCase(); }
+    /** 입력 문자열 공통 정규화: trim → lower(Locale.ROOT) */
+    private static String normalize(String q) {
+        if (q == null) throw new BadRequestException("search query must not be null");
+        q = q.trim();
+        if (q.isEmpty()) throw new BadRequestException("search query must not be blank");
+        return q.toLowerCase(Locale.ROOT);
+    }
+
+    /** 연산자 주변 공백 제거 "a | b" → "a|b", "a - b" → "a-b" */
+    private static String normalizeOperators(String s) {
+        return WS_AROUND_MINUS.matcher(WS_AROUND_PIPE.matcher(s).replaceAll("|")).replaceAll("-");
+    }
 }

--- a/src/test/java/com/trevari/project/search/SearchQueryParserTest.java
+++ b/src/test/java/com/trevari/project/search/SearchQueryParserTest.java
@@ -9,6 +9,16 @@ import static org.junit.jupiter.api.Assertions.*;
 class SearchQueryParserTest {
 
     @Test
+    @DisplayName("단순 검색 API: simple()는 연산자 해석 없이 전체를 SIMPLE로 처리")
+    void parse_simple_api_method() {
+        SearchQuery q = SearchQueryParser.simple("  a|B  ");
+        assertEquals("a|b", q.query());
+        assertEquals("a|b", q.left());
+        assertNull(q.right());
+        assertEquals(SearchStrategy.SIMPLE, q.strategy());
+    }
+
+    @Test
     @DisplayName("단순 키워드 파싱: 공백 제거 및 소문자 정규화")
     void parse_simple_keyword() {
     SearchQuery q = SearchQueryParser.parse("  HelloWorld  ");


### PR DESCRIPTION
## PR 요약
SearchQuery `Simple()` 메서드 및 단위 테스트 추가

## 상세
- `SearchQuery`: 레코드로 변환, 코드 간결화
- `SearchQueryParser`: SIMPLE 전용 메서드 `simple(String)` 추가
- 단위 테스트 추가: `SearchQueryParserTest`에 SIMPLE 전용 API 동작을 검증

## 커밋 (요약)
- refactor(SearchQuery): 레코드로 변환하여 코드 간결화
- feat(SearchQueryParser): SIMPLE 전용 메서드 추가 및 파싱/정규화 리팩토링
- test: 단순 검색 API에 대한 테스트 추가

## 테스트
- 추가된 테스트: `SearchQueryParserTest#parse_simple_api_method`
  - 입력 `"  a|B  "`에 대해 쿼리 전체와 좌측가 소문자·공백 정규화된 `"a|b"`인지 확인
  - 우측은 null, 전략은 `SearchStrategy.SIMPLE`인지 확인
