### PR TITLE
feat: SearchService 클래스 및 검색 메서드 추가

### DIFF
--- a/src/main/java/com/trevari/project/service/SearchService.java
+++ b/src/main/java/com/trevari/project/service/SearchService.java
@@ -1,0 +1,22 @@
+package com.trevari.project.service;
+
+import com.trevari.project.domain.Book;
+import com.trevari.project.repository.BookRepository;
+import com.trevari.project.search.BookSpecifications;
+import com.trevari.project.search.SearchQuery;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@AllArgsConstructor
+@Service
+public class SearchService {
+    private final BookRepository bookRepository;
+
+    @Transactional(readOnly = true)
+    public Page<Book> search(SearchQuery searchQuery, Pageable pageable) {
+        return bookRepository.findAll(BookSpecifications.forQuery(searchQuery), pageable);
+    }
+}

--- a/src/test/java/com/trevari/project/service/SearchServiceTest.java
+++ b/src/test/java/com/trevari/project/service/SearchServiceTest.java
@@ -1,0 +1,81 @@
+package com.trevari.project.service;
+
+import com.trevari.project.domain.Book;
+import com.trevari.project.repository.BookRepository;
+import com.trevari.project.search.SearchQuery;
+import com.trevari.project.search.SearchStrategy;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SearchServiceTest {
+
+    @Mock private BookRepository bookRepository;
+    @InjectMocks private SearchService searchService;
+
+    @Captor ArgumentCaptor<Pageable> pageableCaptor;
+
+    @Test
+    @DisplayName("search() - Repository를 올바른 인자로 1회 호출하고, 반환을 그대로 전달한다")
+    void search_callsRepositoryOnce_withPolicyPageable_andReturnsAsIs() {
+        // given
+        var query = new SearchQuery("ti", "ti", null, SearchStrategy.SIMPLE);
+        var pageable = PageRequest.of(0, 10);
+
+        var book = Book.builder()
+                .isbn("9874151387415")
+                .title("kw_title")
+                .author("author")
+                .build();
+        Page<Book> expected = new PageImpl<>(Collections.singletonList(book), pageable, 1);
+
+        when(bookRepository.findAll(ArgumentMatchers.<Specification<Book>>any(), any(Pageable.class)))
+                .thenReturn(expected);
+
+        // when
+        Page<Book> result = searchService.search(query, pageable);
+
+        // then
+        assertThat(result).isSameAs(expected);
+
+        verify(bookRepository, Mockito.times(1))
+                .findAll(ArgumentMatchers.<Specification<Book>>any(), pageableCaptor.capture());
+        verifyNoMoreInteractions(bookRepository);
+
+        Pageable used = pageableCaptor.getValue();
+        assertThat(used.getPageNumber()).isEqualTo(0);
+        assertThat(used.getPageSize()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("search() - 빈 결과도 그대로 반환한다")
+    void search_returnsEmptyPage() {
+        // given
+        var query = new SearchQuery("ti", "ti", null, SearchStrategy.SIMPLE);
+        var pageable = PageRequest.of(0, 10);
+        when(bookRepository.findAll(ArgumentMatchers.<Specification<Book>>any(), any(Pageable.class)))
+                .thenReturn(Page.empty(pageable));
+
+        // when
+        Page<Book> result = searchService.search(query, pageable);
+
+        // then
+        assertThat(result).isNotNull().isEmpty();
+        verify(bookRepository).findAll(ArgumentMatchers.<Specification<Book>>any(), any(Pageable.class));
+        verifyNoMoreInteractions(bookRepository);
+    }
+}


### PR DESCRIPTION
## 요약

Search 기능에 활용할 `SearchService` 클래스를 추가합니다. 컨트롤러에서 파싱된 `SearchQuery`를 받아 단일 `search()` 메서드로 일관되게 검색을 수행하도록 설계했습니다.

## 변경사항

- `src/main/java/com/trevari/project/service/SearchService.java` 추가
- `src/test/java/com/trevari/project/service/SearchServiceTest.java` 추가

## 설명

서비스는 Repository 수준의 스펙(Specification)을 생성하는 `BookSpecifications.forQuery(searchQuery)`를 사용해 `BookRepository.findAll(spec, pageable)`을 호출합니다. 페이징은 컨트롤러 또는 호출자에서 전달된 `Pageable`을 그대로 사용합니다.

## 테스트

다음 단위 테스트가 포함되어 있습니다:
- `SearchServiceTest#search_callsRepositoryOnce_withPolicyPageable_andReturnsAsIs` - Repository가 적절한 Pageable로 1회 호출되는지, 반환값을 그대로 전달하는지 검증합니다.
- `SearchServiceTest#search_returnsEmptyPage` - 빈 페이지 결과도 정상적으로 반환되는지 검증합니다.