### PR TITLE
feat: NotFoundException 추가

### DIFF
--- a/src/main/java/com/trevari/project/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/trevari/project/exception/GlobalExceptionHandler.java
@@ -22,4 +22,16 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
+
+    /**
+     * 검색 조건에 맞는 도서를 찾지 못한 경우 404 NotFound 응답 반환
+     */
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleNotFoundException(NotFoundException ex) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("status", "error");
+        errorResponse.put("message", ex.getMessage());
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
 }

--- a/src/main/java/com/trevari/project/exception/NotFoundException.java
+++ b/src/main/java/com/trevari/project/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package com.trevari.project.exception;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## 요약
- `NotFoundException` 추가 및 전역 예외처리에 404 핸들러 추가

## 상세
- 목적: 검색 결과가 없을 때 명확한 404 응답 표준화 (특히 Book을 id 기준으로 검색하는 경우)
- 구현: 사용자 정의 예외 `NotFoundException` 생성 및 `GlobalExceptionHandler`에 `@ExceptionHandler` 등록

## 변경 파일
- `NotFoundException.java` — 사용자 정의 런타임 예외 추가
- `GlobalExceptionHandler.java` — NotFoundException 처리 핸들러(HTTP 404, {status,message} 바디) 추가
