### PR TITLE
feat: SearchService 검색 DTO 응답 추가 및 BookService 도입

### DIFF
--- a/src/main/java/com/trevari/project/service/BookService.java
+++ b/src/main/java/com/trevari/project/service/BookService.java
@@ -1,0 +1,26 @@
+package com.trevari.project.service;
+
+import com.trevari.project.domain.Book;
+import com.trevari.project.exception.NotFoundException;
+import com.trevari.project.repository.BookRepository;
+import com.trevari.project.api.dto.SearchDTOs;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@AllArgsConstructor
+@Service
+public class BookService {
+    private final BookRepository bookRepository;
+
+    @Transactional(readOnly = true)
+    public SearchDTOs.Book getBookDTO(String id) {
+        Book b = bookRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Book not found: " + id));
+        return new SearchDTOs.Book(
+                b.getIsbn(), b.getTitle(), b.getSubtitle(), b.getImage(),
+                b.getAuthor(), b.getIsbn(), b.getPublishedDate()
+        );
+    }
+
+}

--- a/src/test/java/com/trevari/project/service/BookServiceTest.java
+++ b/src/test/java/com/trevari/project/service/BookServiceTest.java
@@ -1,0 +1,51 @@
+package com.trevari.project.service;
+
+import com.trevari.project.api.dto.SearchDTOs;
+import com.trevari.project.domain.Book;
+import com.trevari.project.exception.NotFoundException;
+import com.trevari.project.repository.BookRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BookServiceTest {
+
+    @Mock private BookRepository bookRepository;
+    @InjectMocks private BookService bookService;
+
+    @Test
+    @DisplayName("getBookDTOById() - 존재하는 도서면 DTO 반환")
+    void getBookDTOById_returnsDto_whenFound() {
+        var book = Book.builder()
+                .isbn("9781617291609")
+                .title("MongoDB in Action")
+                .author("Kyle Banker")
+                .build();
+
+        when(bookRepository.findById("9781617291609")).thenReturn(Optional.of(book));
+
+        SearchDTOs.Book dto = bookService.getBookDTO("9781617291609");
+
+        assertThat(dto).isNotNull();
+        assertThat(dto.title()).isEqualTo("MongoDB in Action");
+    }
+
+    @Test
+    @DisplayName("getBookDTOById() - 없는 도서면 NotFoundException 발생")
+    void getBookDTOById_throwsNotFound_whenMissing() {
+        when(bookRepository.findById("missing")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> bookService.getBookDTO("missing"))
+                .isInstanceOf(NotFoundException.class);
+    }
+}


### PR DESCRIPTION
## 요약
- 검색 응답을 DTO 형태로 반환하도록 `SearchService`를 변경
- 개별 도서 조회를 위한 `BookService` 및 관련 단위 테스트 추가
- 검색 결과 및 단일 도서에 대해 API 레이어에서 바로 사용할 수 있는 DTO 제공

## 상세
- `SearchService`:
  - 기존 `search()`에서 `Page<Book>`을 반환하는 대신 `getSearchDTO(SearchQuery, Pageable)`를 통해 DTO를 반환
  - `Book` 엔티티를 `SearchDTOs.Book`로 매핑하고 페이지 정보(`SearchDTOs.PageInfo`) 및 메타데이터(`SearchDTOs.Metadata`)를 포함하는 `SearchDTOs.Response` 반환 구현
- `BookService`:
  - `getBookDTO(String id)`: 
    - `BookRepository`에서 `id` 기반으로 `Book`을 검색
    - 단일 도서 조회 시 `SearchDTOs.Book` DTO 반환 구현
  - 도서 미존재 시 `NotFoundException` 발생 처리
- 테스트:
  - `SearchServiceTest`를 수정하여 `getSearchDTO()` 호출 시 repository 호출 검증 및 DTO 응답 빌드 검증 추가
  - `BookServiceTest` 추가로 정상 조회 및 미존재 예외 케이스 검증 추가

## 변경된 주요 파일
- `SearchService.java` — 검색 결과 DTO 빌드 및 반환 구현
- `BookService.java` — 단일 도서 조회 서비스 추가
- `SearchServiceTest.java` — `getSearchDTO()` 테스트로 수정
- `BookServiceTest.java` — `BookService` 테스트 추가