### PR TITLE
feat: BookController 추가

### DIFF
--- a/src/main/java/com/trevari/project/api/BookController.java
+++ b/src/main/java/com/trevari/project/api/BookController.java
@@ -1,0 +1,60 @@
+package com.trevari.project.api;
+
+import com.trevari.project.aop.MeasureTime;
+import com.trevari.project.api.dto.SearchDTOs;
+import com.trevari.project.search.SearchQuery;
+import com.trevari.project.search.SearchQueryParser;
+import com.trevari.project.service.BookService;
+import com.trevari.project.service.SearchService;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/api")
+@Validated
+public class BookController {
+
+    private final SearchService searchService;
+    private final BookService bookService;
+
+    @GetMapping("/books/{id}")
+    public ResponseEntity<SearchDTOs.Book> getBook(@PathVariable("id") String id) {
+        return ResponseEntity.ok(bookService.getBookDTO(id));
+    }
+
+    @MeasureTime
+    @GetMapping("/books") // 리터럴 검색 전용 (SIMPLE 고정)
+    public ResponseEntity<SearchDTOs.Response> browse(
+        @RequestParam("keyword") String keyword,
+        @RequestParam(defaultValue = "1") @Min(1) int page,
+        @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size
+    ) {
+        SearchQuery parsed = SearchQueryParser.simple(keyword); // SIMPLE 확정
+        Pageable pageable = PageRequest.of(page - 1, size);
+        return ResponseEntity.ok(
+                searchService.getSearchDTO(parsed, pageable)
+        );
+    }
+
+    @MeasureTime
+    @GetMapping("/search/books") // 연산자 허용 (없으면 SIMPLE)
+    public ResponseEntity<SearchDTOs.Response> search(
+        @RequestParam("q") String q,
+        @RequestParam(defaultValue = "1") @Min(1) int page,
+        @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size
+    ) {
+        SearchQuery parsed = SearchQueryParser.parse(q); // OR/NOT/SIMPLE 판정
+        Pageable pageable = PageRequest.of(page - 1, size);
+        return ResponseEntity.ok(
+            searchService.getSearchDTO(parsed, pageable)
+        );
+    }
+}

--- a/src/test/java/com/trevari/project/api/BookControllerTest.java
+++ b/src/test/java/com/trevari/project/api/BookControllerTest.java
@@ -1,0 +1,118 @@
+package com.trevari.project.api;
+
+import com.trevari.project.api.dto.SearchDTOs;
+import com.trevari.project.search.SearchQuery;
+import com.trevari.project.search.SearchStrategy;
+import com.trevari.project.service.BookService;
+import com.trevari.project.service.SearchService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class BookControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private SearchService searchService;
+
+    @Mock
+    private BookService bookService;
+
+    @InjectMocks
+    private BookController bookController;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(bookController).build();
+    }
+
+    @Test
+    @DisplayName("/api/books/{ID}: ID로 도서 반환")
+    void get_book_by_id_returns_book() throws Exception {
+        SearchDTOs.Book book = new SearchDTOs.Book(
+            "9786247377209",
+            "테스트 도서",
+            "",
+            "",
+            "저자",
+            "isbn-1",
+            java.time.LocalDate.now()
+        );
+
+        Mockito.when(bookService.getBookDTO(eq("9786247377209"))).thenReturn(book);
+        mockMvc.perform(get("/api/books/9786247377209").accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value("9786247377209"))
+            .andExpect(jsonPath("$.title").value("테스트 도서"));
+    }
+
+    @Test
+    @DisplayName("/api/books: SIMPLE 모드로 페이지 결과 반환")
+    void browse_simple_keyword_returns_page() throws Exception {
+
+        SearchDTOs.Book book = new SearchDTOs.Book(
+            "9786247193209",
+            "타이틀",
+            "",
+            "",
+            "저자1",
+            "isbn-b1",
+            java.time.LocalDate.now()
+        );
+
+        SearchDTOs.PageInfo pageInfo = new SearchDTOs.PageInfo(1, 20, 1, 1L);
+        SearchDTOs.Metadata metadata = new SearchDTOs.Metadata(5L, SearchStrategy.SIMPLE);
+        SearchDTOs.Response resp = new SearchDTOs.Response("keyword", pageInfo, Collections.singletonList(book), metadata);
+
+    Mockito.when(searchService.getSearchDTO(Mockito.<SearchQuery>any(), Mockito.<Pageable>any())).thenReturn(resp);
+
+        mockMvc.perform(get("/api/books").param("keyword", "keyword").param("page", "1").param("size", "20")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.searchQuery").value("keyword"))
+            .andExpect(jsonPath("$.books[0].id").value("9786247193209"));
+    }
+
+    @Test
+    @DisplayName("/api/search/books: q 파라미터로 파싱 후 결과 반환")
+    void search_with_operators_returns_result() throws Exception {
+        SearchDTOs.Book book = new SearchDTOs.Book(
+            "9786242859209",
+            "테스트 도서 제목",
+            "",
+            "",
+            "저자2",
+            "isbn-b2",
+            java.time.LocalDate.now()
+        );
+
+        SearchDTOs.PageInfo pageInfo2 = new SearchDTOs.PageInfo(1, 10, 1, 1L);
+        SearchDTOs.Metadata metadata2 = new SearchDTOs.Metadata(7L, SearchStrategy.OR_OPERATION);
+        SearchDTOs.Response resp = new SearchDTOs.Response("term-other", pageInfo2, Collections.singletonList(book), metadata2);
+
+    Mockito.when(searchService.getSearchDTO(Mockito.<SearchQuery>any(), Mockito.<Pageable>any())).thenReturn(resp);
+        mockMvc.perform(get("/api/search/books").param("q", "term-Other").param("page", "1").param("size", "10")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.searchQuery").value("term-other"))
+            .andExpect(jsonPath("$.books[0].id").value("9786242859209"));
+    }
+}


### PR DESCRIPTION
## 요약
- 기능 추가: `BookController` REST API 및 관련 단위 테스트 추가
- 목적: 도서 조회(단건)와 키워드/연산자 기반 검색 API 제공 및 단위 테스트 추가

## 상세
### 변경된 파일
- BookController.java
  - 역할: 도서 관련 API 엔드포인트를 제공하는 컨트롤러
  - 주요 엔드포인트:
    - `GET /api/books/{id}`: 도서 ID로 단건 조회, `BookService#getBookDTO` 사용
    - `GET /api/books`: 리터럴 키워드 검색(SIMPLE 고정). `SearchQueryParser.simple`를 사용해 SIMPLE 모드로 파싱, `SearchService#getSearchDTO` 호출
    - `GET /api/search/books`: 검색 연산자 허용(OR/NOT 등). `SearchQueryParser.parse`로 파싱 후 `SearchService#getSearchDTO` 호출
  - 어노테이션:
    - `@MeasureTime`: 메서드 수행 시간 측정 AOP 적용
    - 입력 검증: `@Validated`, `@Min`, `@Max` 사용

- BookControllerTest.java
  - `BookController`의 단위 테스트

## 테스트
컨트롤러의 주요 엔드포인트 입력/출력 시나리오를 커버함(단건 조회, SIMPLE 검색, 연산자 허용 검색)
