### PR TITLE
fix: 환경변수 뒤 주석 제거

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,4 +5,5 @@ MYSQL_USER=app
 MYSQL_PASSWORD=app-1234
 MYSQL_ROOT_PASSWORD=app-root-password
 REDIS_HOST=localhost
-REDIS_PORT=6379 # 개발환경 전용
+# 개발 환경 전용
+REDIS_PORT=6379


### PR DESCRIPTION
**오류 발생 환경**: MacOS 환경에서 `.env.template` 파일을 복사해 `.env` 파일로 환경변수를 설정
**오류**: `.env`에 정의된 각 환경변수 값 뒤의 #부분을 주석 처리를 하지 않고, 그대로 환경변수로 사용하는 문제 발생

### 조치

- `.env.template`의 환경변수 뒤 주석 제거
- `.env.template`에 주석이 필요한 경우, 한 줄을 통째로 주석으로 활용하기