### PR TITLE
feat: Redis 기반 인기 검색어 집계 및 조회 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // flyway
     implementation 'org.flywaydb:flyway-core'

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ dependencies {
     // JUnit Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.testcontainers:testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
 
     // H2 DB for DataJpaTest
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/trevari/project/api/BookController.java
+++ b/src/main/java/com/trevari/project/api/BookController.java
@@ -2,9 +2,11 @@ package com.trevari.project.api;
 
 import com.trevari.project.aop.MeasureTime;
 import com.trevari.project.api.dto.SearchDTOs;
+import com.trevari.project.api.dto.SearchKeyword;
 import com.trevari.project.search.SearchQuery;
 import com.trevari.project.search.SearchQueryParser;
 import com.trevari.project.service.BookService;
+import com.trevari.project.service.SearchAggregateService;
 import com.trevari.project.service.SearchService;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -15,6 +17,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 
 @RestController
 @AllArgsConstructor
@@ -24,6 +28,7 @@ public class BookController {
 
     private final SearchService searchService;
     private final BookService bookService;
+    private final SearchAggregateService searchAggregateService;
 
     @GetMapping("/books/{id}")
     public ResponseEntity<SearchDTOs.Book> getBook(@PathVariable("id") String id) {
@@ -56,5 +61,11 @@ public class BookController {
         return ResponseEntity.ok(
             searchService.getSearchDTO(parsed, pageable)
         );
+    }
+
+    @GetMapping("/analytics/search/top10")
+    public ResponseEntity<List<SearchKeyword>> getTop10Keywords() {
+        List<SearchKeyword> topKeywords = searchAggregateService.getTop10Keywords();
+        return ResponseEntity.ok(topKeywords);
     }
 }

--- a/src/main/java/com/trevari/project/api/dto/SearchKeyword.java
+++ b/src/main/java/com/trevari/project/api/dto/SearchKeyword.java
@@ -1,0 +1,4 @@
+package com.trevari.project.api.dto;
+
+// TOP10용 키워드 + 카운트 DTO
+public final record SearchKeyword(String keyword, long count) {}

--- a/src/main/java/com/trevari/project/config/AsyncConfig.java
+++ b/src/main/java/com/trevari/project/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.trevari.project.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "searchAggregateExecutor")
+    public Executor searchAggregateExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("search-aggregate-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/trevari/project/config/RedisConfig.java
+++ b/src/main/java/com/trevari/project/config/RedisConfig.java
@@ -1,0 +1,25 @@
+package com.trevari.project.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        // Key와 Value 모두 String으로 직렬화
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
+
+        return template;
+    }
+}

--- a/src/main/java/com/trevari/project/service/SearchAggregateService.java
+++ b/src/main/java/com/trevari/project/service/SearchAggregateService.java
@@ -19,7 +19,7 @@ import java.util.concurrent.CompletableFuture;
 public class SearchAggregateService {
 
     private final RedisTemplate<String, String> redisTemplate;
-    private static final String SEARCH_KEYWORDS_KEY = "search:keywords:popular";
+    private static final String SEARCH_QUERY_KEY = "search:query:popular";
 
     // 검색어를 집계하여 인기 검색어 순위에 반영 (비동기 처리)
     @Async("searchAggregateExecutor")
@@ -30,7 +30,7 @@ public class SearchAggregateService {
 
         try {
             ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
-            zSetOps.incrementScore(SEARCH_KEYWORDS_KEY, query, 1.0);
+            zSetOps.incrementScore(SEARCH_QUERY_KEY, query, 1.0);
 
             log.debug("검색어 집계 완료: {} (스레드: {})", query, Thread.currentThread().getName());
         } catch (Exception e) {
@@ -44,7 +44,7 @@ public class SearchAggregateService {
     public List<SearchKeyword> getTop10Keywords() {
         try {
             ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
-            Set<ZSetOperations.TypedTuple<String>> topWithScores = zSetOps.reverseRangeWithScores(SEARCH_KEYWORDS_KEY, 0, 9);
+            Set<ZSetOperations.TypedTuple<String>> topWithScores = zSetOps.reverseRangeWithScores(SEARCH_QUERY_KEY, 0, 9);
 
             return Optional.ofNullable(topWithScores)
                     .orElseGet(Set::of) // null이면 빈 Set 반환

--- a/src/main/java/com/trevari/project/service/SearchAggregateService.java
+++ b/src/main/java/com/trevari/project/service/SearchAggregateService.java
@@ -1,0 +1,66 @@
+package com.trevari.project.service;
+
+import com.trevari.project.api.dto.SearchKeyword;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class SearchAggregateService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String SEARCH_KEYWORDS_KEY = "search:keywords:popular";
+
+    // 검색어를 집계하여 인기 검색어 순위에 반영 (비동기 처리)
+    @Async("searchAggregateExecutor")
+    public CompletableFuture<Void> aggregateTop10(String query) {
+        if (query == null || (query = query.trim()).isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        try {
+            ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+            zSetOps.incrementScore(SEARCH_KEYWORDS_KEY, query, 1.0);
+
+            log.debug("검색어 집계 완료: {} (스레드: {})", query, Thread.currentThread().getName());
+        } catch (Exception e) {
+            log.error("검색어 집계 실패: query={}", query, e);
+        }
+
+        return CompletableFuture.completedFuture(null);
+    }
+
+    // 인기 검색어 TOP10 및 조회수 반환
+    public List<SearchKeyword> getTop10Keywords() {
+        try {
+            ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+            Set<ZSetOperations.TypedTuple<String>> topWithScores = zSetOps.reverseRangeWithScores(SEARCH_KEYWORDS_KEY, 0, 9);
+
+            return Optional.ofNullable(topWithScores)
+                    .orElseGet(Set::of) // null이면 빈 Set 반환
+                    .stream()
+                    .map(t -> {
+                        String kw = t.getValue();
+                        Double score = t.getScore();
+                        long cnt = score == null ? 0L : Math.round(score);
+                        return new SearchKeyword(kw, cnt);
+                    })
+                    .toList();
+
+
+        } catch (Exception e) {
+            log.error("인기 검색어 조회 실패", e);
+            return List.of();
+        }
+    }
+}

--- a/src/main/java/com/trevari/project/service/SearchService.java
+++ b/src/main/java/com/trevari/project/service/SearchService.java
@@ -15,9 +15,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class SearchService {
     private final BookRepository bookRepository;
+    private final SearchAggregateService searchAggregateService;
 
     @Transactional(readOnly = true)
     public SearchDTOs.Response getSearchDTO(SearchQuery searchQuery, Pageable pageable) {
+        // 검색어 집계 (인기 검색어 TOP10)
+        searchAggregateService.aggregateTop10(searchQuery.query());
+        
         Page<Book> pageData = bookRepository.findAll(BookSpecifications.forQuery(searchQuery), pageable);
         var items = pageData.getContent().stream()
             .map(b -> new SearchDTOs.Book(

--- a/src/test/java/com/trevari/project/service/SearchAggregateServiceSliceTest.java
+++ b/src/test/java/com/trevari/project/service/SearchAggregateServiceSliceTest.java
@@ -1,0 +1,120 @@
+package com.trevari.project.service;
+
+import com.trevari.project.api.dto.SearchKeyword;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataRedisTest
+@Testcontainers
+@Import({SearchAggregateService.class, SearchAggregateServiceSliceTest.AsyncTestConfig.class})
+class SearchAggregateServiceSliceTest {
+
+    @Autowired
+    RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    SearchAggregateService searchAggregateService;
+
+    // Testcontainers Redis (테스트 전용)
+    @Container
+    @SuppressWarnings("resource")
+    static final GenericContainer<?> redis =
+            new GenericContainer<>(DockerImageName.parse("redis:7"))
+                    .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redisProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.redis.host", redis::getHost);
+        registry.add("spring.redis.port", () -> redis.getMappedPort(6379));
+    }
+
+    @BeforeEach
+    // 테스트 메서드 2개 이상일 경우, 이전 테스트의 부작용이 남지 않도록 처리
+    void setUp() {
+        redisTemplate.execute((RedisCallback<Object>) connection -> {
+            connection.serverCommands().flushDb();
+            return null;
+        });
+    }
+
+    @Test
+    @DisplayName("단순 집계 통합: 검색어 집계 후 TOP10에 반영됨")
+    void aggregate_simple_keyword_and_get_top10() {
+        // Given: 키워드별 호출 횟수 정의
+        Map<String, Integer> counts = new LinkedHashMap<>();
+        counts.put("spring boot", 2);
+        counts.put("mongo-java", 5);
+        counts.put("tdd-javascript", 3);
+
+        // When: Map을 이용해 반복적으로 비동기 집계 호출
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (Map.Entry<String, Integer> e : counts.entrySet()) {
+            String k = e.getKey();
+            int times = e.getValue();
+            for (int i = 0; i < times; i++) {
+                futures.add(searchAggregateService.aggregateTop10(k));
+            }
+        }
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+        // Then: TOP 결과 확인 (내림차순으로 정렬되어야 함)
+        List<SearchKeyword> top = searchAggregateService.getTop10Keywords();
+        assertThat(top).isNotEmpty();
+
+        // 카운트 맵 값 기반 예상 순서: mongo-java(5), tdd-javascript(3), spring boot(2)
+        Map<String, Long> expected = new LinkedHashMap<>();
+        expected.put("mongo-java", 5L);
+        expected.put("tdd-javascript", 3L);
+        expected.put("spring boot", 2L);
+
+        int idx = 0;
+        for (Map.Entry<String, Long> e : expected.entrySet()) {
+            assertThat(top.get(idx).keyword()).isEqualTo(e.getKey());
+            assertThat(top.get(idx).count()).isEqualTo(e.getValue());
+            idx++;
+        }
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration(exclude = RedisRepositoriesAutoConfiguration.class)
+    @EnableAsync
+    static class AsyncTestConfig {
+        @Bean(name = "searchAggregateExecutor")
+        public Executor searchAggregateExecutor() {
+            ThreadPoolTaskExecutor exec = new ThreadPoolTaskExecutor();
+            exec.setCorePoolSize(2);
+            exec.setMaxPoolSize(4);
+            exec.setQueueCapacity(50);
+            exec.setThreadNamePrefix("test-search-agg-");
+            exec.initialize();
+            return exec;
+        }
+    }
+}

--- a/src/test/java/com/trevari/project/service/SearchServiceTest.java
+++ b/src/test/java/com/trevari/project/service/SearchServiceTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.*;
 class SearchServiceTest {
 
     @Mock private BookRepository bookRepository;
+    @Mock private SearchAggregateService searchAggregateService;
     @InjectMocks private SearchService searchService;
 
     @Captor ArgumentCaptor<Pageable> pageableCaptor;

--- a/src/test/java/com/trevari/project/service/SearchServiceTest.java
+++ b/src/test/java/com/trevari/project/service/SearchServiceTest.java
@@ -64,6 +64,9 @@ class SearchServiceTest {
         Pageable used = pageableCaptor.getValue();
         assertThat(used.getPageNumber()).isEqualTo(0);
         assertThat(used.getPageSize()).isEqualTo(10);
+
+        // 인기 검색어 집계는 검색 흐름에서 단 한번만 호출되어야 함
+        verify(searchAggregateService, times(1)).aggregateTop10(query.query());
     }
 
     @Test


### PR DESCRIPTION
### 상세
- Redis 의존성 및 설정 추가: build.gradle에 `spring-boot-starter-data-redis` 추가, `RedisConfig`로 `RedisTemplate<String,String>` 빈 등록
- 비동기 처리 설정 추가: `AsyncConfig`에서 `searchAggregateExecutor` 빈 등록 및 `@EnableAsync` 활성화
- 인기 검색어 집계 서비스 추가: `SearchAggregateService` 구현 (ZSet에 점수 증가, 키: `search:query:popular`)
- DTO 추가: `SearchKeyword` 레코드 추가 (키워드 + 카운트).
- 검색 흐름 통합: `SearchService`에서 검색 시 `searchAggregateService.aggregateTop10(...)` 호출 횟수 검증 추가
- 컨트롤러 엔드포인트 추가: `BookController`에 `GET /api/analytics/search/top10` 추가하여 인기 검색어 목록 반환
- 테스트 관련:
  - 의존성: build.gradle에 Testcontainers 의존성 추가
  - Testcontainers 기반 Redis 슬라이스 통합 테스트 추가: `SearchAggregateServiceSliceTest`로 집계 및 TOP10 검증
  - 기존 단위테스트 보강: `SearchServiceTest`에서 집계 호출 검증 추가
  - `BookControllerTest`에 TOP10 엔드포인트 테스트 추가

### 테스트
- SearchAggregateServiceSliceTest
  - Given: 키워드별 호출 횟수 설정
  - When: 각 키워드를 반복적으로 집계 호출(비동기)
  - Then: `getTop10Keywords()`가 내림차순으로 집계 결과를 반환하는지 검증 (정확한 순서 및 카운트)
- SearchServiceTest
  - Given/When: 기존 검색 흐름 실행
  - Then: 검색 시 `searchAggregateService.aggregateTop10(...)`가 정확히 1회 호출되는지 검증
- BookControllerTest
  - Given/When: `GET /api/analytics/search/top10` 호출
  - Then: 응답으로 인기 검색어 리스트(키워드 + 카운트) 반환되는지 검증