### PR TITLE
fix: Testcontainers Redis 설정 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     // JUnit Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation "org.springframework.boot:spring-boot-testcontainers"
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
 

--- a/src/test/java/com/trevari/project/service/SearchAggregateServiceSliceTest.java
+++ b/src/test/java/com/trevari/project/service/SearchAggregateServiceSliceTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.RedisCallback;
@@ -44,16 +45,10 @@ class SearchAggregateServiceSliceTest {
 
     // Testcontainers Redis (테스트 전용)
     @Container
+    @ServiceConnection
     @SuppressWarnings("resource")
     static final GenericContainer<?> redis =
-            new GenericContainer<>(DockerImageName.parse("redis:7"))
-                    .withExposedPorts(6379);
-
-    @DynamicPropertySource
-    static void redisProps(DynamicPropertyRegistry registry) {
-        registry.add("spring.redis.host", redis::getHost);
-        registry.add("spring.redis.port", () -> redis.getMappedPort(6379));
-    }
+            new GenericContainer<>("redis:7").withExposedPorts(6379);
 
     @BeforeEach
     // 테스트 메서드 2개 이상일 경우, 이전 테스트의 부작용이 남지 않도록 처리


### PR DESCRIPTION
### 요약
Testcontainers Redis 대신 로컬 환경에서 돌고 있는 기존 Redis에 연결되는 문제 해결

### 상세
`@ServiceConnection` 어노테이션을 사용하여 Testcontainers Redis 연결 설정 단순화
**문제**: 기존의 `@DynamicPropertySource`를 통한 수동 프로퍼티 설정 (localhost:6379 사용)
**해결**: Spring Boot Testcontainers의 자동 연결 기능을 활용하도록 변경