### PR TITLE
docs: Swagger UI 및 OpenAPI 문서화 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,11 @@ dependencies {
 
     // H2 DB for DataJpaTest
     runtimeOnly 'com.h2database:h2'
+
+    // Swagger (springdoc-openapi)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+      implementation("org.apache.commons:commons-lang3:3.18.0")    // 취약점 패치 버전 강제
+      implementation("org.apache.commons:commons-compress:1.26.0") // 취약점 패치 버전 강제
 }
 
 tasks.named('test') {

--- a/src/main/java/com/trevari/project/api/BookController.java
+++ b/src/main/java/com/trevari/project/api/BookController.java
@@ -10,6 +10,9 @@ import com.trevari.project.service.SearchAggregateService;
 import com.trevari.project.service.SearchService;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -20,7 +23,19 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 
+/**
+ * REST API 진입점: 도서 조회 및 검색 관련 엔드포인트를 제공합니다.
+ *
+ * <p>주요 엔드포인트:
+ * <ul>
+ *   <li>GET  /api/books/{id}            : ID로 단건 도서 조회</li>
+ *   <li>GET  /api/books                 : 단순 키워드(SIMPLE)로 페이징 검색</li>
+ *   <li>GET  /api/search/books          : 고급 검색(OR/NOT 등 연산자 허용)</li>
+ *   <li>GET  /api/analytics/search/top10: 인기 검색어 TOP10 조회</li>
+ * </ul>
+ */
 @RestController
+@Tag(name = "Book API", description = "책 조회 및 검색 관련 API")
 @AllArgsConstructor
 @RequestMapping("/api")
 @Validated
@@ -30,17 +45,33 @@ public class BookController {
     private final BookService bookService;
     private final SearchAggregateService searchAggregateService;
 
+    /**
+     * 단건 도서 조회
+     *
+     * @param id 도서 식별자
+     * @return 도서 응답 DTO
+     */
     @GetMapping("/books/{id}")
+    @Operation(summary = "책 단건 조회", description = "ID로 책 상세 정보를 조회합니다.")
     public ResponseEntity<SearchDTOs.Book> getBook(@PathVariable("id") String id) {
         return ResponseEntity.ok(bookService.getBookDTO(id));
     }
 
+    /**
+     * 단순 키워드로 도서를 조회합니다. (SIMPLE 검색 모드 고정)
+     *
+     * @param keyword 검색 키워드 (리터럴)
+     * @param page 1 기반 페이지 번호
+     * @param size 페이지 크기 (최대 100)
+     * @return 페이징된 검색 결과
+     */
     @MeasureTime
     @GetMapping("/books") // 리터럴 검색 전용 (SIMPLE 고정)
+    @Operation(summary = "리터럴 키워드로 책 목록 조회", description = "단순 키워드로 책을 검색합니다. 페이징 지원")
     public ResponseEntity<SearchDTOs.Response> browse(
-        @RequestParam("keyword") String keyword,
-        @RequestParam(defaultValue = "1") @Min(1) int page,
-        @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size
+        @Parameter(description = "검색 키워드 (단순 텍스트)") @RequestParam("keyword") String keyword,
+        @Parameter(description = "페이지 번호 (1 기반)") @RequestParam(defaultValue = "1") @Min(1) int page,
+        @Parameter(description = "페이지 사이즈") @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size
     ) {
         SearchQuery parsed = SearchQueryParser.simple(keyword); // SIMPLE 확정
         Pageable pageable = PageRequest.of(page - 1, size);
@@ -49,12 +80,21 @@ public class BookController {
         );
     }
 
+    /**
+     * 고급 검색: OR/NOT 등의 연산자를 포함한 쿼리를 파싱하여 검색을 수행합니다.
+     *
+     * @param q 검색 쿼리 문자열
+     * @param page 1 기반 페이지 번호
+     * @param size 페이지 크기 (최대 100)
+     * @return 페이징된 검색 결과
+     */
     @MeasureTime
     @GetMapping("/search/books") // 연산자 허용 (없으면 SIMPLE)
+    @Operation(summary = "고급 검색", description = "OR/NOT 등의 연산자를 포함한 고급 검색을 수행합니다.")
     public ResponseEntity<SearchDTOs.Response> search(
-        @RequestParam("q") String q,
-        @RequestParam(defaultValue = "1") @Min(1) int page,
-        @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size
+        @Parameter(description = "검색 쿼리 (OR/NOT 등 사용 가능)") @RequestParam("q") String q,
+        @Parameter(description = "페이지 번호 (1 기반)") @RequestParam(defaultValue = "1") @Min(1) int page,
+        @Parameter(description = "페이지 사이즈") @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size
     ) {
         SearchQuery parsed = SearchQueryParser.parse(q); // OR/NOT/SIMPLE 판정
         Pageable pageable = PageRequest.of(page - 1, size);
@@ -63,7 +103,16 @@ public class BookController {
         );
     }
 
+    /**
+     * 인기 검색어 TOP10을 반환합니다.
+     *
+     * <p>이 엔드포인트는 검색 집계 서비스에서 집계된 결과를 반환하며, UI나 리포트에서
+     * 상위 검색어를 표시할 때 사용됩니다.
+     *
+     * @return 상위 10개 검색어 리스트
+     */
     @GetMapping("/analytics/search/top10")
+    @Operation(summary = "상위 10 검색어 조회", description = "가장 많이 검색된 상위 10개 키워드를 반환합니다.")
     public ResponseEntity<List<SearchKeyword>> getTop10Keywords() {
         List<SearchKeyword> topKeywords = searchAggregateService.getTop10Keywords();
         return ResponseEntity.ok(topKeywords);

--- a/src/main/java/com/trevari/project/api/dto/SearchDTOs.java
+++ b/src/main/java/com/trevari/project/api/dto/SearchDTOs.java
@@ -1,46 +1,55 @@
 package com.trevari.project.api.dto;
 
 import com.trevari.project.search.SearchStrategy;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDate;
 import java.util.List;
 
 /**
- * 도서 검색 응답 DTO 묶음
+ * <p>도서 검색 응답 DTO 묶음:
+ * <ul>
+ *   <li>Response: 전체 응답 래퍼 (검색어, 페이징정보, 도서 목록, 메타)</li>
+ *   <li>PageInfo: 페이징 관련 정보</li>
+ *   <li>Book: 단건 도서 응답 구조</li>
+ *   <li>Metadata: 검색 메타데이터</li>
+ * </ul>
  */
+@Schema(description = "도서 검색 응답 DTO 묶음")
 public final class SearchDTOs {
     private SearchDTOs() {} // 네임스페이스 용, 인스턴스화 방지
 
-    // 상위 응답 DTO
+    // 검색 응답 래퍼
+    @Schema(description = "검색 응답 래퍼: 검색어, 페이징 정보, 도서 목록, 메타데이터를 포함")
     public record Response(
-            String searchQuery,
-            PageInfo pageInfo,
-            List<Book> books,
-            Metadata searchMetadata
+            @Schema(description = "정규화된 검색 쿼리 문자열") String searchQuery,
+            @Schema(description = "페이징 정보") PageInfo pageInfo,
+            @Schema(description = "도서 목록") List<Book> books,
+            @Schema(description = "검색 실행 메타데이터") Metadata searchMetadata
     ) {}
 
-    // 페이지 정보
+    @Schema(description = "페이징 관련 정보")
     public record PageInfo(
-            int currentPage,
-            int pageSize,
-            int totalPages,
-            long totalElements
+            @Schema(description = "현재 페이지 번호") int currentPage,
+            @Schema(description = "페이지 크기") int pageSize,
+            @Schema(description = "전체 페이지 수") int totalPages,
+            @Schema(description = "전체 요소 수") long totalElements
     ) {}
 
-    // 도서 정보
+    @Schema(description = "단건 도서 응답 구조")
     public record Book(
-            String id,
-            String title,
-            String subtitle,
-            String image,
-            String author,
-            String isbn,
-            LocalDate published
+            @Schema(description = "식별자 (ISBN과 동일)") String id,
+            @Schema(description = "도서 제목") String title,
+            @Schema(description = "부제") String subtitle,
+            @Schema(description = "표지 이미지 URL") String image,
+            @Schema(description = "저자") String author,
+            @Schema(description = "ISBN") String isbn,
+            @Schema(description = "출간일 (YYYY-MM-DD)") LocalDate published
     ) {}
 
-    // 검색 메타데이터
+    @Schema(description = "검색 메타데이터")
     public record Metadata(
-            long executionTime,
-            SearchStrategy strategy
+            @Schema(description = "검색 실행 시간(ms)") long executionTime,
+            @Schema(description = "사용한 검색 전략") SearchStrategy strategy
     ) {}
 }

--- a/src/main/java/com/trevari/project/api/dto/SearchKeyword.java
+++ b/src/main/java/com/trevari/project/api/dto/SearchKeyword.java
@@ -1,4 +1,10 @@
 package com.trevari.project.api.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 // TOP10용 키워드 + 카운트 DTO
-public final record SearchKeyword(String keyword, long count) {}
+@Schema(description = "상위 검색어와 카운트")
+public final record SearchKeyword(
+	@Schema(description = "검색 키워드") String keyword,
+	@Schema(description = "검색 횟수") long count
+) {}

--- a/src/main/java/com/trevari/project/config/OpenApiConfig.java
+++ b/src/main/java/com/trevari/project/config/OpenApiConfig.java
@@ -1,0 +1,18 @@
+package com.trevari.project.config;
+
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.OpenAPI;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI().info(
+            new Info()
+                .title("Trevari Project API")
+                .version("1.0")
+                .description("트레바리 도서 API 설명"));
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -28,5 +28,14 @@ spring:
     enabled: false
     locations: classpath:db/migration
 
+springdoc:
+  api-docs:
+    enabled: true
+    path: /v3/api-docs
+  swagger-ui:
+    enabled: true
+    path: /swagger-ui.html
+    url: /v3/api-docs
+
 server:
   port: 8080


### PR DESCRIPTION
## 요약

- 프로젝트에 Swagger UI를 도입하여 API 문서화 환경 구축 
- 개발자들이 API를 쉽게 테스트하고 이해할 수 있도록 springdoc-openapi를 활용해 자동 문서 생성 체계 마련

### 주요 변경사항

**의존성 및 보안 강화**
- `springdoc-openapi-starter-webmvc-ui` 2.8.9 버전 추가
- 보안 취약점 해결을 위한 `commons-lang3` 및 `commons-compress` 버전 강제 업데이트

**OpenAPI 설정**
- `OpenApiConfig` 클래스를 통한 API 기본 정보 설정
- `application.yaml`에서 Swagger UI 경로 및 활성화 설정

**API 문서화**
- `BookController`의 모든 엔드포인트에 상세한 Swagger 어노테이션 적용
- 각 파라미터와 응답에 대한 명확한 설명 추가
- 검색 API의 차이점(단순 검색 vs 고급 검색) 명시

**DTO 스키마 정의**
- `SearchDTOs`와 `SearchKeyword`의 모든 필드에 스키마 설명 추가
- API 응답 구조를 문서에서 직관적으로 파악 가능

### 접근 경로

- Swagger API 문서: `/swagger-ui.html`
- OpenAPI 스펙(JSON): `/v3/api-docs`