### PR TITLE
fix: Flyway 관련 설정 제거 및 application.yaml 정리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,10 +30,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-    // flyway
-    implementation 'org.flywaydb:flyway-core'
-    implementation 'org.flywaydb:flyway-mysql'
-
     // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,29 +4,24 @@ spring:
   application:
     name: project
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://${DB_HOST:localhost}:3306/${MYSQL_DATABASE}?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=utf8
     username: ${MYSQL_USER}
     password: ${MYSQL_PASSWORD}
   sql:
     init:
       mode: always
-
-  data:
-    redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
-
   jpa:
     open-in-view: false
     hibernate:
       ddl-auto: update
     properties:
       hibernate.format_sql: true
+    defer-datasource-initialization: true
 
-  flyway:
-    enabled: false
-    locations: classpath:db/migration
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
 springdoc:
   api-docs:


### PR DESCRIPTION
### flyway 제거 이유

간단한 과제 수준에 맞춰 현재 `data.sql`을 로드하는 방식으로 충분하다고 판단

### application.yaml 정리

DB 드라이버 설정 제거: 다중 DB를 사용하는 환경은 아니기에 드라이버를 직접 설정할 필요는 없음
`defer-datasource-initialization`: JPA가 엔티티 기반으로 테이블을 먼저 생성해주기 위한 설정