### PR TITLE
chore(docker): 컨테이너 어플리케이션 빌드 및 실행 설정

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,22 +1,18 @@
-# 프로젝트 마무리 단계 작업
-# app도 함께 컨테이너 빌드 및 실행하도록 주석 제거
-# (현재는 Intellij 디버깅 활용하기 위해 주석 처리 및 직접 실행)
-# db, redis 포트 정보 제거
-
 services:
-#  app:
-#    build:
-#      context: .
-#      dockerfile: docker/Dockerfile
-#    depends_on:
-#      db:
-#        condition: service_healthy
-#    environment:
-#      SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/${MYSQL_DATABASE}?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=utf8
-#      SPRING_DATASOURCE_USERNAME: ${MYSQL_USER}
-#      SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD}
-#      SPRING_REDIS_HOST: ${SPRING_REDIS_HOST}
-#    ports: ["8080:8080"]
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/${MYSQL_DATABASE}?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=utf8
+      SPRING_DATASOURCE_USERNAME: ${MYSQL_USER}
+      SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD}
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+    ports: ["8080:8080"]
 
   db:
     image: mysql:8.4
@@ -25,7 +21,6 @@ services:
       MYSQL_USER: ${MYSQL_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-    ports: ["3306:3306"]
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_0900_ai_ci
@@ -37,4 +32,3 @@ services:
 
   redis:
     image: redis:7
-    ports: ["6379:6379"]


### PR DESCRIPTION
## 요약
컨테이너 빌드 및 실행을 위해 `docker-compose.yaml`의 app 서비스 주석 해제
DB/Redis 포트 바인딩을 제거하여 컨테이너 환경에 맞게 구성 업데이트

## 상세
- `docker-compose.yaml`에서 `app` 서비스를 활성화하여 프로젝트를 컨테이너로 빌드·실행할 수 있도록 변경
- `app.environment`에 Redis 연결을 위한 `REDIS_HOST` 및 `REDIS_PORT` 추가
- `db`와 `redis` 서비스의 외부 포트 매핑(`ports`)을 제거(컨테이너 내부 통신만 사용)
