### PR TITLE
test: 인기검색 집계 호출 검증 Service -> Controller로 이전

### DIFF
--- a/src/test/java/com/trevari/project/service/SearchServiceTest.java
+++ b/src/test/java/com/trevari/project/service/SearchServiceTest.java
@@ -64,9 +64,6 @@ class SearchServiceTest {
         Pageable used = pageableCaptor.getValue();
         assertThat(used.getPageNumber()).isEqualTo(0);
         assertThat(used.getPageSize()).isEqualTo(10);
-
-        // 인기 검색어 집계는 검색 흐름에서 단 한번만 호출되어야 함
-        verify(searchAggregateService, times(1)).aggregateTop10(query.query());
     }
 
     @Test


### PR DESCRIPTION
### 문제

#30 변경에 따라, test도 변경되어야 함.

### 해결

- 인기 검색 집계 호출을 `SearchServiceTest`에서 `BookControllerTest`로 이동
- 인기 검색 집계 호출 검증과 DTO응답 반환 검증은 서로 역할이 다르므로 테스트를 분리