### PR TITLE
test: 통합테스트 추가

### DIFF
--- a/src/test/java/com/trevari/project/ProjectApplicationTests.java
+++ b/src/test/java/com/trevari/project/ProjectApplicationTests.java
@@ -2,8 +2,10 @@ package com.trevari.project;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class ProjectApplicationTests {
 
     @Test

--- a/src/test/java/com/trevari/project/integration/BookE2ETest.java
+++ b/src/test/java/com/trevari/project/integration/BookE2ETest.java
@@ -71,31 +71,13 @@ public class BookE2ETest {
     }
 
     @Test
-    @DisplayName("통합: 단순 키워드 검색 -> Redis 집계 반영 및 인기검색어 확인")
-    void searchAggregatesToRedis() throws Exception {
+    @DisplayName("통합: 단순 키워드 검색 응답 확인")
+    void searchNotAggregatesToRedis() throws Exception {
         String keyword = "spring";
 
         String url = "/api/books?keyword=" + keyword;
         ResponseEntity<SearchDTOs.Response> resp = restTemplate.getForEntity(url, SearchDTOs.Response.class);
         assertThat(resp.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(resp.getBody()).isNotNull();
-
-        String topUrl = "/api/analytics/search/top10";
-
-        // 비동기 집계가 반영될 때까지 최대 5초 동안 폴링
-        boolean found = false;
-        long deadline = System.currentTimeMillis() + Duration.ofSeconds(5).toMillis();
-        while (System.currentTimeMillis() < deadline) {
-            ResponseEntity<SearchKeyword[]> topResp = restTemplate.getForEntity(topUrl, SearchKeyword[].class);
-            assertThat(topResp.getStatusCode().is2xxSuccessful()).isTrue();
-            SearchKeyword[] body = topResp.getBody();
-            if (body != null) {
-                found = List.of(body).stream().anyMatch(k -> k.keyword().equalsIgnoreCase(keyword));
-                if (found) break;
-            }
-            Thread.sleep(100);
-        }
-
-        assertThat(found).isTrue();
     }
 }

--- a/src/test/java/com/trevari/project/integration/BookE2ETest.java
+++ b/src/test/java/com/trevari/project/integration/BookE2ETest.java
@@ -1,0 +1,69 @@
+package com.trevari.project.integration;
+
+import com.trevari.project.api.dto.SearchDTOs;
+import com.trevari.project.api.dto.SearchKeyword;
+import com.trevari.project.domain.Book;
+import com.trevari.project.repository.BookRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Testcontainers
+public class BookE2ETest {
+
+    @Autowired
+    TestRestTemplate restTemplate;
+
+    // Testcontainers Redis (테스트 전용)
+    @Container
+    @ServiceConnection
+    @SuppressWarnings("resource")
+    static final GenericContainer<?> redis =
+            new GenericContainer<>("redis:7").withExposedPorts(6379);
+
+    @Test
+    @DisplayName("통합: 단순 키워드 검색 -> Redis 집계 반영 및 인기검색어 확인")
+    void searchAggregatesToRedis() throws Exception {
+        String keyword = "spring";
+
+        String url = "/api/books?keyword=" + keyword;
+        ResponseEntity<SearchDTOs.Response> resp = restTemplate.getForEntity(url, SearchDTOs.Response.class);
+        assertThat(resp.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(resp.getBody()).isNotNull();
+
+        String topUrl = "/api/analytics/search/top10";
+
+        // 비동기 집계가 반영될 때까지 최대 5초 동안 폴링
+        boolean found = false;
+        long deadline = System.currentTimeMillis() + Duration.ofSeconds(5).toMillis();
+        while (System.currentTimeMillis() < deadline) {
+            ResponseEntity<SearchKeyword[]> topResp = restTemplate.getForEntity(topUrl, SearchKeyword[].class);
+            assertThat(topResp.getStatusCode().is2xxSuccessful()).isTrue();
+            SearchKeyword[] body = topResp.getBody();
+            if (body != null) {
+                found = List.of(body).stream().anyMatch(k -> k.keyword().equalsIgnoreCase(keyword));
+                if (found) break;
+            }
+            Thread.sleep(100);
+        }
+
+        assertThat(found).isTrue();
+    }
+}


### PR DESCRIPTION
## PR 요약
- 통합 테스트(E2E) 추가: 검색 관련 통합 시나리오들 추가
- Redis 연동 및 인기 검색어 집계 검증 테스트 포함
- 단건 조회 API E2E 테스트 및 테스트 데이터 시드 추가
- 테스트 프로파일 활성화

## 상세 변경사항
- 통합 테스트 클래스 `BookE2ETest` 추가
  - Redis Testcontainers를 사용해 테스트 전용 Redis를 띄우고, 검색 집계(인기검색어) 확인 테스트를 구현했습니다.
  - 검색(쿼리) 연산자 케이스를 포함한 검색 경로 테스트 추가하여 복합 쿼리(예: "spring|java")의 집계 반영을 검증합니다.
- 기존 `ProjectApplicationTests`에 테스트 프로파일(`test`) 활성화 주석 제거 및 어노테이션 추가
- 테스트 리소스(`application-test.yaml`)를 사용하도록 통합 테스트가 활성화됩니다.

## 커밋 특이사항
- fc7fdda: 테스트: 단순 키워드 검색 응답 확인 테스트로 변경
  - 통합테스트 작성 도중 [#30](https://github.com/Jaehyuk-Lee/trevari-project/pull/30) 에서 로직 변경이 발생하여 통합테스트에서 관련 검증 로직을 제거함
