### PR TITLE
feat: 도서 상세 정보 조회 기능 추가 및 BookDetailDTO 사용

### DIFF
--- a/src/main/java/com/trevari/project/api/BookController.java
+++ b/src/main/java/com/trevari/project/api/BookController.java
@@ -1,6 +1,7 @@
 package com.trevari.project.api;
 
 import com.trevari.project.aop.MeasureTime;
+import com.trevari.project.api.dto.BookDetailDTO;
 import com.trevari.project.api.dto.SearchDTOs;
 import com.trevari.project.api.dto.SearchKeyword;
 import com.trevari.project.search.SearchQuery;
@@ -53,8 +54,8 @@ public class BookController {
      */
     @GetMapping("/books/{id}")
     @Operation(summary = "책 단건 조회", description = "ID로 책 상세 정보를 조회합니다.")
-    public ResponseEntity<SearchDTOs.Book> getBook(@PathVariable("id") String id) {
-        return ResponseEntity.ok(bookService.getBookDTO(id));
+    public ResponseEntity<BookDetailDTO> getBook(@PathVariable("id") String id) {
+        return ResponseEntity.ok(bookService.getBookDetailDTO(id));
     }
 
     /**

--- a/src/main/java/com/trevari/project/api/dto/BookDetailDTO.java
+++ b/src/main/java/com/trevari/project/api/dto/BookDetailDTO.java
@@ -1,0 +1,17 @@
+package com.trevari.project.api.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+@Schema(description = "단건 도서 응답 구조")
+public record BookDetailDTO(
+        @Schema(description = "식별자 (ISBN과 동일)") String id,
+        @Schema(description = "도서 제목") String title,
+        @Schema(description = "부제") String subtitle,
+        @Schema(description = "표지 이미지 URL") String image,
+        @Schema(description = "저자") String author,
+        @Schema(description = "ISBN") String isbn,
+        @Schema(description = "출판사") String publisher,
+        @Schema(description = "출간일 (YYYY-MM-DD)") LocalDate published
+) {}

--- a/src/main/java/com/trevari/project/api/dto/SearchDTOs.java
+++ b/src/main/java/com/trevari/project/api/dto/SearchDTOs.java
@@ -36,7 +36,7 @@ public final class SearchDTOs {
             @Schema(description = "전체 요소 수") long totalElements
     ) {}
 
-    @Schema(description = "단건 도서 응답 구조")
+    @Schema(description = "검색 결과 도서 정보")
     public record Book(
             @Schema(description = "식별자 (ISBN과 동일)") String id,
             @Schema(description = "도서 제목") String title,

--- a/src/main/java/com/trevari/project/service/BookService.java
+++ b/src/main/java/com/trevari/project/service/BookService.java
@@ -1,9 +1,9 @@
 package com.trevari.project.service;
 
+import com.trevari.project.api.dto.BookDetailDTO;
 import com.trevari.project.domain.Book;
 import com.trevari.project.exception.NotFoundException;
 import com.trevari.project.repository.BookRepository;
-import com.trevari.project.api.dto.SearchDTOs;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,12 +14,12 @@ public class BookService {
     private final BookRepository bookRepository;
 
     @Transactional(readOnly = true)
-    public SearchDTOs.Book getBookDTO(String id) {
+    public BookDetailDTO getBookDetailDTO(String id) {
         Book b = bookRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("Book not found: " + id));
-        return new SearchDTOs.Book(
+        return new BookDetailDTO(
                 b.getIsbn(), b.getTitle(), b.getSubtitle(), b.getImage(),
-                b.getAuthor(), b.getIsbn(), b.getPublishedDate()
+                b.getAuthor(), b.getIsbn(), b.getPublisher(), b.getPublishedDate()
         );
     }
 

--- a/src/test/java/com/trevari/project/api/BookControllerTest.java
+++ b/src/test/java/com/trevari/project/api/BookControllerTest.java
@@ -63,7 +63,7 @@ class BookControllerTest {
             "",
             "",
             "저자",
-            "isbn-1",
+            "9786247377209",
             "출판사",
             java.time.LocalDate.now()
         );
@@ -86,7 +86,7 @@ class BookControllerTest {
             "",
             "",
             "저자1",
-            "isbn-b1",
+            "9786247193209",
             java.time.LocalDate.now()
         );
 
@@ -122,7 +122,7 @@ class BookControllerTest {
             "",
             "",
             "저자2",
-            "isbn-b2",
+            "9786242859209",
             java.time.LocalDate.now()
         );
 
@@ -146,7 +146,7 @@ class BookControllerTest {
                 "",
                 "",
                 "저자2",
-                "isbn-b2",
+                "9786242859209",
                 java.time.LocalDate.now()
         );
 

--- a/src/test/java/com/trevari/project/api/BookControllerTest.java
+++ b/src/test/java/com/trevari/project/api/BookControllerTest.java
@@ -1,5 +1,6 @@
 package com.trevari.project.api;
 
+import com.trevari.project.api.dto.BookDetailDTO;
 import com.trevari.project.api.dto.SearchDTOs;
 import com.trevari.project.api.dto.SearchKeyword;
 import com.trevari.project.search.SearchQuery;
@@ -56,21 +57,23 @@ class BookControllerTest {
     @Test
     @DisplayName("GET /api/books/{ID}: ID로 도서 반환")
     void get_book_by_id_returns_book() throws Exception {
-        SearchDTOs.Book book = new SearchDTOs.Book(
+        BookDetailDTO book = new BookDetailDTO(
             "9786247377209",
             "테스트 도서",
             "",
             "",
             "저자",
             "isbn-1",
+            "출판사",
             java.time.LocalDate.now()
         );
 
-        Mockito.when(bookService.getBookDTO(eq("9786247377209"))).thenReturn(book);
+        Mockito.when(bookService.getBookDetailDTO(eq("9786247377209"))).thenReturn(book);
         mockMvc.perform(get("/api/books/9786247377209").accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.id").value("9786247377209"))
-            .andExpect(jsonPath("$.title").value("테스트 도서"));
+            .andExpect(jsonPath("$.title").value("테스트 도서"))
+            .andExpect(jsonPath("$.publisher").value("출판사"));
     }
 
     @Test

--- a/src/test/java/com/trevari/project/service/BookServiceTest.java
+++ b/src/test/java/com/trevari/project/service/BookServiceTest.java
@@ -1,6 +1,6 @@
 package com.trevari.project.service;
 
-import com.trevari.project.api.dto.SearchDTOs;
+import com.trevari.project.api.dto.BookDetailDTO;
 import com.trevari.project.domain.Book;
 import com.trevari.project.exception.NotFoundException;
 import com.trevari.project.repository.BookRepository;
@@ -24,8 +24,8 @@ class BookServiceTest {
     @InjectMocks private BookService bookService;
 
     @Test
-    @DisplayName("getBookDTOById() - 존재하는 도서면 DTO 반환")
-    void getBookDTOById_returnsDto_whenFound() {
+    @DisplayName("getBookDetailDTO() - 존재하는 도서면 DTO 반환")
+    void getBookDetailDTOById_returnsDetailDto_whenFound() {
         var book = Book.builder()
                 .isbn("9781617291609")
                 .title("MongoDB in Action")
@@ -34,18 +34,18 @@ class BookServiceTest {
 
         when(bookRepository.findById("9781617291609")).thenReturn(Optional.of(book));
 
-        SearchDTOs.Book dto = bookService.getBookDTO("9781617291609");
+        BookDetailDTO dto = bookService.getBookDetailDTO("9781617291609");
 
         assertThat(dto).isNotNull();
         assertThat(dto.title()).isEqualTo("MongoDB in Action");
     }
 
     @Test
-    @DisplayName("getBookDTOById() - 없는 도서면 NotFoundException 발생")
-    void getBookDTOById_throwsNotFound_whenMissing() {
+    @DisplayName("getBookDetailDTO() - 없는 도서면 NotFoundException 발생")
+    void getBookDetailDTOById_throwsNotFound_whenMissing() {
         when(bookRepository.findById("missing")).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> bookService.getBookDTO("missing"))
+        assertThatThrownBy(() -> bookService.getBookDetailDTO("missing"))
                 .isInstanceOf(NotFoundException.class);
     }
 }


### PR DESCRIPTION
### 요약
도서 단건 조회 응답을 `BookDetailDTO`로 분리하여 상세 정보를 반환하도록 변경했습니다.

### 변경사항
- `BookDetailDTO` 추가
- `BookController`의 GET /api/books/{id} 반환 타입 → `BookDetailDTO`
- `BookService` 메서드명/반환 수정 (`getBookDetailDTO`)
- 관련 단위 테스트 (`BookControllerTest`, `BookServiceTest`) 업데이트

### 영향
검색 결과용 DTO와 상세 조회 DTO가 분리되어 API 응답 형식이 변경됩니다. 클라이언트가 `publisher` 필드를 추가로 응답받습니다.

### 기타

테스트에서 사용하는 데이터의 id값이 isbn과 불일치하던 문제를 해결했습니다.