### PR TITLE
chore(docker): gradle 이미지에서 alpine 태그 제거 — Apple Silicon 지원

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Build stage ----
-FROM gradle:8.10.2-jdk17-alpine AS build
+FROM gradle:8.10.2-jdk17 AS build
 WORKDIR /workspace
 COPY . .
 RUN gradle clean bootJar --no-daemon


### PR DESCRIPTION
alpine 버전의 이미지는 Apple Sillion CPU를 지원하지 않아 Mac에서 Docker 빌드가 실패하는 문제를 해결합니다.