### PR TITLE
docs: README 및 도메인 모델 문서 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,243 @@
-# 도서 검색 API 시스템 (Trevari Project)
+# 도서 검색 API 시스템
 
-> 백엔드 개발자 과제 구현용 백엔드 서비스 (Java Spring Boot 기반)
+## 프로젝트 개요
 
-### 실행 전 준비
+도서 카탈로그를 검색하고, 도서 상세를 조회할 수 있는 REST API 서비스입니다. 인기 검색어 조회 기능도 제공합니다.
 
-- 반드시 `.env` 파일이 필요합니다.
-- DB 컨테이너(MySQL)는 `.env`에 정의된 사용자/비밀번호/DB 정보를 기반으로 초기화되며,
-  Spring Boot 애플리케이션도 동일한 환경변수를 사용하여 DB에 접속합니다.
-- 따라서 `.env` 파일이 없으면 프로젝트를 실행할 수 없습니다.
+## 도메인 모델
 
-#### .env.example 파일 사용하기
+도서는 고유 식별자(ISBN)를 가지며 기본 정보와 출판 정보를 포함합니다.
 
-프로젝트에는 실행 편의를 위해 `.env.example` 파일이 포함되어 있습니다.
-이 파일에는 **샘플 값**이 들어 있으며, 그대로 사용하면 로컬 환경에서 바로 실행할 수 있습니다.
+- Book 엔티티 속성 (타입, DB 매핑, 검증)
+  - `isbn` (String) — PK, 길이 제한 20, null 불가. 예: "9781617291609"
+  - `title` (String) — 길이 제한 255, null 불가.
+  - `subtitle` (String) — 길이 제한 255, nullable.
+  - `author` (String) — 길이 제한 255, null 불가.
+  - `publisher` (String) — 길이 제한 255, nullable.
+  - `publishedDate` (LocalDate) — DB 컬럼명 `published_date`, API 응답 필드명: `published` (ISO-8601, yyyy-MM-dd), nullable.
+  - `image` (String) — 이미지 URL, 길이 제한 512, nullable.
 
-1. `.env.example` 파일을 복사하여 `.env`로 이름을 변경합니다.
-   ```bash
-   cp .env.example .env
-    ```
+간단한 API 응답 예시 (Book 객체):
+```json
+{
+  "id": "9781617291609",
+  "title": "MongoDB in Action, 2nd Edition",
+  "subtitle": "Covers MongoDB version 3.0",
+  "author": "Kyle Banker",
+  "isbn": "9781617291609",
+  "publisher": "Manning",
+  "published": "2016-03-01",
+  "image": "https://itbook.store/img/books/9781617291609.png"
+}
+```
 
-2. 필요하다면 값들을 수정합니다.
+검증/비즈니스 노트:
+- `isbn`, `title`, `author`는 필수 필드입니다. (엔티티에서 `@NotNull`로 검증)
+- `publishedDate`는 ISO-8601 형식(yyyy-MM-dd)으로 직렬화됩니다.
+- `isbn`은 외부 키(ISBN 표준) 규격 유효성 검증은 구현되지 않았음(필요시 확장 가능).
 
-   * `MYSQL_DATABASE`, `MYSQL_USER`, `MYSQL_PASSWORD`는 MySQL 컨테이너 초기화 및 Spring Boot DB 접속에 사용됩니다.
-   * `MYSQL_ROOT_PASSWORD`는 MySQL 루트 계정 비밀번호입니다.
-   * `SPRING_REDIS_HOST`, `SPRING_REDIS_PORT`는 Redis 연결에 사용됩니다.
+### 더 자세한 도메인 설계
 
-3. 샘플 값 그대로 두고 실행하면 `docker compose up -d` 후 애플리케이션이 정상적으로 동작합니다.
+자세한 도메인 모델링 문서는 [여기](/docs/domain.md)를 참고하세요.
 
-⚠️ 실제 운영 환경에서는 반드시 `.env`의 값들을 안전한 자격 증명으로 변경해야 합니다.
+## API 엔드포인트 예시
 
-### EditorConfig
+- GET /api/books?keyword={keyword}&page={page}&size={size}
+- GET /api/books/{id}
+- GET /api/search/books?q={query}&page={page}&size={size}
+- GET /api/analytics/search/top10
 
-EditorConfig(`.editorconfig`)를 사용해 에디터 설정과 줄바꿈(EOL)을 통일해, 환경별 불필요한 diff 발생을 줄였습니다.
+응답 예시(요약):
 
-### Docker compose
+```json
+{
+  "searchQuery": "tdd|javascript",
+  "pageInfo": { "currentPage": 1, "pageSize": 20, "totalPages": 5, "totalElements": 100 },
+  "books": [ /* Book 객체 배열 */ ],
+  "searchMetadata": { "executionTime": 23, "strategy": "OR_OPERATION" }
+}
+```
 
-#### MySQL 설정
+## 실행 방법
 
-서비스 간 의존성을 고려하여 healthcheck 추가 및 depends_on 의존성 설정
+1. `.env` 또는 환경 변수 설정 (`.env.example` 참조)
+    - `.env.example` 파일을 그대로 `.env`로 복사해도 작동
+2. Docker Compose로 DB 포함 전체 서비스 구동
+    - 예: `docker compose up -d`
+3. 애플리케이션 접속 및 API 호출 (Swagger UI 또는 Postman 사용)
+
+## API 문서 링크
+
+Docker 컨테이너 실행 이후 접속 가능
+
+- Swagger UI: http://localhost:8080/swagger-ui/index.html
+
+## 초기 데이터
+
+프로젝트는 시드 데이터를 포함합니다. 최소 100건 이상의 샘플 도서가 DB에 적재되도록 초기화 스크립트를 제공합니다.
+
+[data.sql](/src/main/resources/data.sql) 참고
+
+## 기술 스택
+
+- 언어/프레임워크: Java Spring Boot
+  - 가장 익숙한 웹 어플리케이션 서버 프레임워크
+  - 레이어드 아키텍처를 통한 책임의 분리
+  - Spring AOP를 통한 간편한 관심사의 분리
+  - 버전: JDK 17 / Spring Boot 3
+    - Virtual Thread 등의 JDK 21 기능을 사용할 필요성 낮음
+    - 기간 안에 안정적으로 개발할 수 있도록 JDK 17 선택
+- 데이터베이스: MySQL
+  - 관계형 데이터베이스 중 가장 보편적이고, LIKE 기반 검색이 간단
+- 동적 검색 구현: JPA Specification
+  - OR / NOT (+AND) 연산자 검색
+- 테스트:
+  - 단위 및 통합 테스트 :JUnit
+- 테스트 환경:
+  - RDB 테스트: H2
+    - 테스트 환경에서 간단히 데이터베이스를 사용 가능
+  - Redis 테스트: Testcontainers (Redis)
+    - 개발 환경과 테스트 환경 Redis 분리를 위해 test-containers 도입
+
+## 아키텍처 결정 사항
+
+* **검색 파이프라인**: 쿼리 파싱 → 검색 전략 결정(SIMPLE / OR / NOT) → JPA Specification 조합 → 결과 집계
+* **검색 키워드 제한**: 한 번의 요청에서 최대 2개 키워드만 허용
+* **동적 검색 구현 방식**: JPQL/QueryDSL 대신 **JPA Specification** 채택
+  * 이유: 이번 과제 범위에서는 설정 부담이 적고 빠르게 적용 가능
+* **인기 검색어 집계 규칙**: 연산자 검색(`GET /api/search/books`)에서만 집계
+* **테스트 환경 분리**
+  * RDB: H2 (MySQL 호환 모드)
+  * Redis: Testcontainers (개발 환경과 격리)
+
+## 테스트
+
+테스트은 단위 테스트와 일부 통합 테스트를 포함합니다.
+
+### 테스트 실행 방법
+
+Docker가 실행되고 있어야 합니다.
+
+`./gradlew test`로 실행 가능합니다.
+
+### 단위 테스트 대상
+
+- Controller
+  - BookController
+- Service
+  - BookService
+  - SearchService
+- SearchQueryParser
+- Aspect
+  - ExecutionTimeAspect
+
+### 슬라이스 테스트 대상
+
+- Repository
+  - BookSpecification + BookRepository + H2
+- SearchAggregateService (인기 검색어 Redis 집계 및 조회 서비스)
+  - SearchAggregateService + Redis
+
+### 통합 테스트 대상
+
+- BookE2ETest
+  - 단건 조회 API E2E
+  - 단순 검색 응답 확인
+  - 연산자 검색 -> Redis 집계 반영 및 인기검색어 확인
+
+## 문제 해결 및 고민한 점
+
+### JPA Specification
+
+- 현재: 정적 쿼리와 JPQL은 이미 알고 있는 상황
+- 도전: JPA Specification이라는 새로운 기술을 도입해보는 것이 효과적일까?
+
+기술 난이도 낮음 ← **정적 쿼리** - **JPQL** - JPA Specification - QueryDSL → 복잡도가 높은 프로젝트에서 유지보수성 향상
+
+#### 기술 탐색
+
+- JPA Specification 장단점 확인
+- 사용 예시를 ChatGPT에게 요청
+
+#### 유지보수성
+
+- 가독성
+- 조건 조립 유연성
+
+#### 검색 조건
+
+- 5가지 검색 조건("isbn", "title", "subtitle", "author", "publisher") 사용
+- OR 연산과 NOT (+AND) 연산 조립 필요
+
+**결정**: Specification을 활용해 필요에 따라 조건을 조립
+
+### 검색 엔드포인트 분리
+
+과제 예시에 다음과 같이 검색 엔드포인트가 두 가지로 분리되어 제시되었습니다.
+
+```
+GET /api/books?keyword={keyword}
+GET /api/search/books?q={query}
+```
+
+따라서, 검색 기능을 두 가지로 분리해보았습니다.
+
+#### 연산자 검색
+
+검색 연산자를 허용하는 검색 기능
+
+`GET /api/search/books?q={query}`에 요청하면, 연산자를 판독해 `SIMPLE`/`OR`/`NOT` 검색 전략 중에서 선택합니다.
+
+#### 단순 검색
+
+키워드만 입력받는 단순 검색 기능
+
+`GET /api/books?keyword={keyword}`에 요청하면, 연산자가 포함되어도 항상 `SIMPLE` 전략으로 검색을 진행합니다.
+
+### 인덱스
+
+#### 문제
+
+LIKE ’%kw%’ 같은 연산을 하면 인덱스를 제대로 태우기 어려움
+
+#### 대안
+
+- FULLTEXT 인덱스: 단어 단위로 인덱싱 → 완벽한 부분 검색 기능에 적절치 않음
+- N-gram 인덱스: N글자 단위로 잘라 인덱싱 → 부분 문자열 검색은 가능하나 인덱스 크기와 성능 비용이 큼
+- 대용량 데이터를 사용해서 인덱싱 기능이 반드시 필요하다면 elasticSearch로 이전하는 것이 좋을 것
+  - 프로젝트 규모에 비해 기술 도입 비용이 과다하다고 판단
+
+#### 결정
+
+시드 데이터는 100개 이상으로 소규모 데이터를 다루는 과제이기 때문에 인덱스를 배제함
+
+### 인기검색어 집계
+
+- 상황: 같은 문자열로 검색해도 '단순 검색' 혹은 '연산자 검색'에 따라 검색 결과가 달라짐
+- 문제:
+  - 단순 검색 `mongo-test`와 연산자 검색 `mongo-test`는 서로 다른 검색. 하지만 검색어는 동일.
+  - 따라서, 사용자 입장에서 인기검색어가 정확히 어떤 검색인지 알기 어려움.
+- 해결: 연산자 검색을 사용하는 경우에만 인기 검색어를 집계하도록 설계
+
+이에 관한 이슈: [#29](https://github.com/Jaehyuk-Lee/trevari-project/issues/29)
+
+### NOT (+AND) 검색 관련
+
+- 발견: Repository 슬라이스 테스트 도중 NOT 연산과 관련된 테스트가 실패하는 것을 확인
+- 문제: NULL 값이 포함된 필드의 NOT 검색 결과가 UNKNOWN 처리되어, 필드간 후속 OR 연산에서 전체 쿼리 결과를 오염
+- 해결: NOT 조건 검색 결과에 COALESCE를 통해 NULL 대신 "" 빈 문자열을 사용하도록 변경
+
+### Testcontainers
+
+- 문제: 테스트를 진행하면 개발 환경의 Redis에 부작용을 남김
+- 해결: 격리된 테스트 환경 필요성 확인. Testcontainers로 해결이 가능하여 빠르게 도입
+
+### 검색 쿼리의 모호성 처리
+
+일반적인 검색:
+- 키워드 양옆의 공백은 무시
+- 대소문자 구분하지 않음
+
+### 기타
+
+- MacOS 환경에서는 .env 인라인 주석 허용하지 않음. 행주석 사용. - [#23](https://github.com/Jaehyuk-Lee/trevari-project/pull/23)

--- a/docs/domain.md
+++ b/docs/domain.md
@@ -1,0 +1,220 @@
+# 도메인 모델
+
+## 1) 도메인 개요
+
+이 시스템은 **도서(Book) 카탈로그**를 중심으로,
+
+* 사용자의 **도서 검색**(단순/복합 연산)
+* **도서 상세 조회**
+* **인기 검색어 집계/조회**
+
+를 제공하는 **검색 중심 도메인**입니다. API 응답에는 검색 실행 메타데이터(실행 시간, 전략 등)가 포함됩니다.
+
+도메인은 크게 세 하위 영역으로 나뉩니다.
+
+* **Catalog**: 도서 엔티티의 저장/조회 (RDBMS, JPA)
+* **Search**: 검색 쿼리 파싱, Specification 기반 검색 (SIMPLE / OR / NOT)
+* **Analytics**: 검색어 집계 및 TOP10 조회 (Redis ZSET, 비동기 집계)
+
+## 2) 도메인 객체
+
+### 2.1 Book (Entity)
+
+* 위치: `com.trevari.project.domain.Book`
+* 저장소: RDBMS (`books` 테이블)
+* **식별자**: `isbn` (String) — Equals/HashCode는 isbn 기준
+* **주요 속성**
+  * `title` (String, not null)
+  * `subtitle` (String)
+  * `author` (String, not null)
+  * `publisher` (String)
+  * `publishedDate` (LocalDate, 컬럼명 `published_date`)
+  * `image` (String, 표지 이미지 URL)
+* **불변 조건/관례**
+  * `isbn`, `title`, `author`는 비어선 안 됨(NotNull)
+  * API 단에서는 `id == isbn`으로 동일하게 취급
+
+### 2.2 SearchQuery (Value Object)
+
+* 위치: `com.trevari.project.search.SearchQuery`
+* 필드: `query`, `left`, `right`, `strategy`
+* **의미**
+  * `SIMPLE`: 단일 키워드 검색
+  * `OR`: `left | right`
+  * `NOT`: `left - right`
+* 생성은 **파서**를 통해 일관성 있게 이뤄집니다.
+
+### 2.3 SearchStrategy (Enum)
+
+* 위치: `com.trevari.project.search.SearchStrategy`
+* 값: `SIMPLE`, `OR`, `NOT`
+* **행위적 의미**: Book 검색 시 어떤 조합의 `Specification`을 만들지 결정
+
+## 3) 도메인 서비스 / 응용 서비스
+
+### 3.1 BookService (응용 서비스)
+
+* 위치: `com.trevari.project.service.BookService`
+* 역할: 단건 상세 조회 흐름 조립
+
+  * `getBookDetailDTO(id)` → `BookRepository.findById` → DTO 매핑
+  * 존재하지 않을 경우 `NotFoundException`
+
+### 3.2 SearchService (응용 서비스)
+
+* 위치: `com.trevari.project.service.SearchService`
+* 역할: 검색 흐름 조립
+
+  * `getSearchDTO(SearchQuery, Pageable)`
+  * `BookSpecifications.forQuery(searchQuery)`를 통해 `Specification<Book>` 생성
+  * Page 결과를 `SearchDTOs`로 매핑 (목록/페이징/메타데이터)
+
+### 3.3 SearchAggregateService (도메인/응용 혼합, Analytics)
+
+* 위치: `com.trevari.project.service.SearchAggregateService`
+* 역할:
+
+  * **검색어 집계(비동기)**: `aggregateTop10(query)`
+    * Redis ZSET(`search:query:popular`)에 `query`의 score 증가
+    * `@Async("searchAggregateExecutor")`로 처리 (최소한의 쓰기 지연)
+  * **TOP10 조회**: `getTop10()`
+
+    * ZSET에서 상위 10개 `(keyword, count)` 가공 후 반환
+* 일관성 모델: **최종 일관성(Eventual Consistency)**
+  검색 직후 TOP10에 바로 반영되지 않을 수 있음
+
+## 4) 규칙과 제약 (도메인 정책)
+
+### 4.1 검색 쿼리 파싱 규칙
+
+* 위치: `com.trevari.project.search.SearchQueryParser`
+* 입력 문자열 전처리:
+  * 대소문자 정규화(소문자)
+  * `|` 또는 `-` 연산자 좌우 공백 정규화
+* 허용되는 연산:
+  * `SIMPLE`(연산자 없음)
+  * `OR`(`a | b`) — **정확히 2개 키워드**
+  * `NOT`(`a - b`) — **정확히 2개 키워드**
+* 제약/검증:
+  * `|`와 `-` 동시 사용 금지 → `BadRequestException`
+  * `OR/NOT`에서 한쪽이라도 비어있으면 → `BadRequestException`
+  * 키워드는 최대 2개까지 (요구사항 맞춤)
+
+### 4.2 검색 사양(Specification) 규칙
+
+* 위치: `com.trevari.project.search.BookSpecifications`
+* 검색 대상 필드: `title`, `subtitle`, `author`, `publisher`
+* `contains(kw)`:
+  * 공백/빈값이면 **항상 거짓**(disjunction) — SIMPLE=0건, OR/NOT 조합 시 중립화 의도
+  * `lower()` + `like "%kw%"` 형태로 매칭
+* 전략별 조합:
+  * `SIMPLE` → `contains(query)`
+  * `OR` → `contains(left) OR contains(right)`
+  * `NOT` → `contains(left) AND NOT contains(right)`
+
+### 4.3 예외/에러 정책
+
+* `NotFoundException`: 도서 상세 조회 시 미존재
+* `BadRequestException`: 잘못된 쿼리/연산자 조합
+* `GlobalExceptionHandler`: 공통 예외 변환(HTTP 상태/메시지 표준화)
+
+## 5) 레포지토리
+
+### BookRepository
+
+* 위치: `com.trevari.project.repository.BookRepository`
+* 상속: `JpaRepository<Book, String>`, `JpaSpecificationExecutor<Book>`
+* 역할: Book 엔티티 영속성 책임 + Specification 기반 동적 쿼리 처리
+
+## 6) 읽기 모델 / DTO
+
+### SearchDTOs
+
+* 위치: `com.trevari.project.api.dto.SearchDTOs`
+* **구성**
+  * `Response`: `searchQuery`, `pageInfo`, `books`, `searchMetadata`
+  * `PageInfo`: `currentPage`, `pageSize`, `totalPages`, `totalElements`
+  * `Book`: 단건 요약(목록용)
+  * `Metadata`: `strategy`, `elapsedMs` 등
+* 특징: 컨트롤러/서비스에서 곧바로 응답 가능하도록 설계
+
+### BookDetailDTO
+
+* 위치: `com.trevari.project.api.dto.BookDetailDTO`
+* 역할: 상세 조회 응답 전용
+
+### SearchKeyword (인기 검색어용)
+
+* 위치: `com.trevari.project.api.dto.SearchKeyword`
+* 역할: `(keyword, count)` 쌍으로 TOP10 응답
+
+## 7) 횡단 관심사 (AOP)
+
+### ExecutionTimeAspect
+
+* 위치: `com.trevari.project.aop.ExecutionTimeAspect`, `@MeasureTime`
+* 역할: 검색 API 실행 시간을 `elapsedMs`로 계산해 `SearchDTOs.Metadata`에 주입
+  (컨트롤러에서 `ResponseEntity<SearchDTOs.Response>`를 반환하는 경우에만 적용)
+
+## 8) 유스케이스 & 흐름
+
+### 8.1 도서 검색 (SIMPLE / OR / NOT)
+
+```
+[Client]
+   │  GET /api/search/books?q=java|spring&page=1&size=10
+   ▼
+[BookController]
+   ├─ SearchQueryParser.parse(q) → SearchQuery(strategy=OR, left=java, right=spring, query=java|spring)
+   ├─ SearchAggregateService.aggregateTop10(parsed.query()) (비동기)
+   ├─ SearchService.getSearchDTO(searchQuery, pageable)
+   │    ├─ BookSpecifications.forQuery(searchQuery)
+   │    ├─ BookRepository.findAll(spec, pageable) → Page<Book>
+   │    └─ SearchDTOs.Response 구성(목록/페이지/메타)
+   └─ ResponseEntity<SearchDTOs.Response> 반환 (AOP로 elapsedMs 주입)
+```
+
+### 8.2 도서 상세 조회
+
+```
+[Client] ── GET /api/books/{isbn}
+   ▼
+[BookController]
+   ├─ BookService.getBookDetailDTO(isbn)
+   ├─ BookRepository.findById(isbn) or NotFoundException
+   └─ BookDetailDTO 반환
+```
+
+### 8.3 인기 검색어 TOP10
+
+```
+[Client] ── GET /api/analytics/search/top10
+   ▼
+[BookController]
+   ├─ SearchAggregateService.getTop10()
+   ├─ Redis ZSET "search:query:popular" 상위 10개 조회
+   └─ List<SearchKeyword> 반환
+```
+
+## 9) 저장소 & 인프라 모델
+
+* **RDBMS (JPA)**: Book 카탈로그의 단일 진실 소스(SoT)
+  * 테이블: `books`
+  * 조회는 Specification 기반 동적 조건
+* **Redis (ZSET)**: 인기 검색어 집계(쓰기 빠름, 순위 조회 용이)
+  * 키: `search:query:popular`
+  * 값: member=`query`, score=`count`
+  * 읽기는 eventual (집계 비동기)
+
+## 10) 경계(바운디드 컨텍스트)와 의존성
+
+* **Catalog(books)** ↔ **Search**: Search는 Catalog를 조회 대상으로 사용
+* **Search** ↔ **Analytics**: Search는 Analytics에 쓰기를 위임(비동기), Analytics는 별도 조회 API 제공
+* API 레이어는 응용 서비스(SearchService/BookService, SearchAggregateService)에만 의존
+
+## 11) 확장 포인트
+
+* **검색 필드 확장**: `BookSpecifications.FIELDS`에 컬럼 추가
+* **전략 확장**: `SearchStrategy` + `BookSpecifications.forQuery` 조합 추가
+* **정렬/스코어링**: 사양 결합 혹은 별도 Query DSL/전용 검색엔진 도입 여지
+* **집계 지연/주기 조정**: `@Async` 실행자/큐 정책 변경으로 트래픽 대응


### PR DESCRIPTION
`README`와 `domain.md` 문서 정리: 

- `README`: 실행 방법·핵심 API·간단한 Book 엔티티 속성·테스트 실행 방법·기술 스택·고민 과정 추가
- `domain.md`: 상세한 도메인 설계(검색 파이프라인, Specification 규칙, 인기검색어 집계 흐름 등) 분리